### PR TITLE
Correct padding for strings with multi-byte chars

### DIFF
--- a/modules/core/src/main/java/com/illposed/osc/utility/OSCJavaToByteArrayConverter.java
+++ b/modules/core/src/main/java/com/illposed/osc/utility/OSCJavaToByteArrayConverter.java
@@ -227,8 +227,8 @@ public class OSCJavaToByteArrayConverter {
 */
 		byte[] stringBytes = aString.getBytes(charset);
 
-		// pad out to align on 4 byte boundry
-		int mod = aString.length() % 4;
+		// pad out to align on 4 byte boundary
+		int mod = stringBytes.length % 4;
 		int pad = 4 - mod;
 
 		byte[] newBytes = new byte[pad + stringBytes.length];

--- a/modules/core/src/test/java/com/illposed/osc/utility/OSCJavaToByteArrayConverterTest.java
+++ b/modules/core/src/test/java/com/illposed/osc/utility/OSCJavaToByteArrayConverterTest.java
@@ -12,6 +12,8 @@ import com.illposed.osc.OSCMessageTest;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.nio.charset.Charset;
+
 /**
  * This implementation is based on Markus Gaelli and Iannis Zannos's
  * <a href="http://www.emergent.de/Goodies/">OSC implementation in Squeak</a>
@@ -74,6 +76,16 @@ public class OSCJavaToByteArrayConverterTest {
 		byte[] result = stream.toByteArray();
 		checkResultEqualsAnswer(result, answer);
 	}
+
+    @Test
+    public void testPrintString3OnStream() {
+        OSCJavaToByteArrayConverter stream = new OSCJavaToByteArrayConverter();
+        stream.setCharset(Charset.forName("UTF-8"));
+        stream.write("\u00e1"); // LATIN SMALL LETTER A WITH ACUTE
+        byte[] answer = {(byte) 0xc3, (byte) 0xa1, 0, 0};
+        byte[] result = stream.toByteArray();
+        checkResultEqualsAnswer(result, answer);
+    }
 
 	@Test
 	public void testPrintStringOnStream() {


### PR DESCRIPTION
This is a trivial bug fix for a situation when string arguments that contained characters that were encoded in multiple bytes got wrong padding. It happened because the length in chars instead of length in bytes was used to calculate the number of padding bytes.
