### PR TITLE
Make listening variable volatile for thread-safety

### DIFF
--- a/modules/core/src/main/java/com/illposed/osc/transport/udp/OSCPortIn.java
+++ b/modules/core/src/main/java/com/illposed/osc/transport/udp/OSCPortIn.java
@@ -52,7 +52,7 @@ public class OSCPortIn extends OSCPort implements Runnable {
 	 */
 	public static final int BUFFER_SIZE = 65507;
 
-	private boolean listening;
+	private volatile boolean listening;
 	private boolean daemonListener;
 	private boolean resilient;
 	private Thread listeningThread;


### PR DESCRIPTION
This should make OSCPortIn thread-safe as long as `startListening()` and `stopListening()` are only called from a single thread. Takes care of part of issue #4.