### PR TITLE
Working towards fixing `mvn install` compile errors for Java 8

### DIFF
--- a/modules/core/src/main/java/com/illposed/osc/ConsoleEchoServer.java
+++ b/modules/core/src/main/java/com/illposed/osc/ConsoleEchoServer.java
@@ -26,7 +26,8 @@ import java.nio.charset.Charset;
  */
 public class ConsoleEchoServer extends OSCPortIn {
 
-	@SuppressWarnings("WeakerAccess") // Public API
+	// Public API
+	@SuppressWarnings("WeakerAccess")
 	public static final int DEFAULT_PORT = 7770;
 	private static final int ARG_INDEX_ADDRESS = 0;
 	private static final int ARG_INDEX_PORT = 1;
@@ -55,7 +56,8 @@ public class ConsoleEchoServer extends OSCPortIn {
 
 	}
 
-	@SuppressWarnings("WeakerAccess") // Public API
+	// Public API
+	@SuppressWarnings("WeakerAccess")
 	public ConsoleEchoServer(final SocketAddress serverAddress, final PrintStream out) throws IOException {
 		super(
 				OSCParserFactory.createDefaultFactory(),
@@ -65,7 +67,8 @@ public class ConsoleEchoServer extends OSCPortIn {
 		this.out = out;
 	}
 
-	@SuppressWarnings("WeakerAccess") // Public API
+	// Public API
+	@SuppressWarnings("WeakerAccess")
 	public void start() {
 
 		final OSCMessageListener listener = new EchoOSCMessageListener(out);
@@ -83,7 +86,8 @@ public class ConsoleEchoServer extends OSCPortIn {
 				getLocalAddress().toString());
 	}
 
-	@SuppressWarnings("WeakerAccess") // Public API
+	// Public API
+	@SuppressWarnings("WeakerAccess")
 	public static SocketAddress parseServerAddress(final String[] args)
 			throws UnknownHostException
 	{

--- a/modules/core/src/main/java/com/illposed/osc/EchoOSCMessageListener.java
+++ b/modules/core/src/main/java/com/illposed/osc/EchoOSCMessageListener.java
@@ -8,7 +8,6 @@
 
 package com.illposed.osc;
 
-import com.illposed.osc.argument.OSCTimeTag64;
 import java.io.PrintStream;
 
 /**
@@ -46,13 +45,15 @@ public class EchoOSCMessageListener implements OSCMessageListener {
 
 	private final PrintStream out;
 
-	@SuppressWarnings("WeakerAccess") // Public API
+	// Public API
+	@SuppressWarnings("WeakerAccess")
 	public EchoOSCMessageListener(final PrintStream out) {
 
 		this.out = out;
 	}
 
-	@SuppressWarnings("unused") // Public API
+	// Public API
+	@SuppressWarnings("unused")
 	public EchoOSCMessageListener() {
 		this(System.out);
 	}

--- a/modules/core/src/main/java/com/illposed/osc/LibraryInfo.java
+++ b/modules/core/src/main/java/com/illposed/osc/LibraryInfo.java
@@ -30,7 +30,8 @@ import java.util.Set;
 public final class LibraryInfo {
 
 	private static final String MANIFEST_FILE = "/META-INF/MANIFEST.MF";
-	@SuppressWarnings("WeakerAccess") // Public API
+	// Public API
+	@SuppressWarnings("WeakerAccess")
 	public static final String UNKNOWN_VALUE = "<unknown>";
 	private static final char MANIFEST_CONTINUATION_LINE_INDICATOR = ' ';
 	/** 1 key + 1 value = 2 parts of a key-value pair */
@@ -114,21 +115,24 @@ public final class LibraryInfo {
 		return mavenProps;
 	}
 
+	// Public API
 	/**
 	 * Returns this application JARs {@link #MANIFEST_FILE} properties.
 	 * @return the contents of the manifest file as {@code String} to {@code String} mapping
 	 */
-	@SuppressWarnings("WeakerAccess") // Public API
+	@SuppressWarnings("WeakerAccess")
 	public Properties getManifestProperties() {
 		return manifestProperties;
 	}
 
-	@SuppressWarnings("WeakerAccess") // Public API
+	// Public API
+	@SuppressWarnings("WeakerAccess")
 	public String getVersion() {
 		return getManifestProperties().getProperty("Bundle-Version", UNKNOWN_VALUE);
 	}
 
-	@SuppressWarnings("WeakerAccess") // Public API
+	// Public API
+	@SuppressWarnings("WeakerAccess")
 	public String getOscSpecificationVersion() {
 		return getManifestProperties().getProperty("Supported-OSC-Version", UNKNOWN_VALUE);
 	}
@@ -137,22 +141,26 @@ public final class LibraryInfo {
 		return getManifestProperties().getProperty("Bundle-License", UNKNOWN_VALUE);
 	}
 
-	@SuppressWarnings("WeakerAccess") // Public API
+	// Public API
+	@SuppressWarnings("WeakerAccess")
 	public boolean isArrayEncodingSupported() {
 		return true;
 	}
 
-	@SuppressWarnings("WeakerAccess") // Public API
+	// Public API
+	@SuppressWarnings("WeakerAccess")
 	public boolean isArrayDecodingSupported() {
 		return true;
 	}
 
-	@SuppressWarnings("WeakerAccess") // Public API
+	// Public API
+	@SuppressWarnings("WeakerAccess")
 	public List<ArgumentHandler> getEncodingArgumentHandlers() {
 		return OSCSerializerFactory.createDefaultFactory().getArgumentHandlers();
 	}
 
-	@SuppressWarnings("WeakerAccess") // Public API
+	// Public API
+	@SuppressWarnings("WeakerAccess")
 	public Map<Character, ArgumentHandler> getDecodingArgumentHandlers() {
 		return OSCParserFactory.createDefaultFactory().getIdentifierToTypeMapping();
 	}
@@ -188,7 +196,8 @@ public final class LibraryInfo {
 		return classOrMarkerValue;
 	}
 
-	@SuppressWarnings("unused") // Public API
+	// Public API
+	@SuppressWarnings("unused")
 	public String createManifestPropertiesString() {
 
 		final StringBuilder info = new StringBuilder(1024);
@@ -206,7 +215,8 @@ public final class LibraryInfo {
 		return info.toString();
 	}
 
-	@SuppressWarnings("WeakerAccess") // Public API
+	// Public API
+	@SuppressWarnings("WeakerAccess")
 	public String createLibrarySummary() {
 
 		final StringBuilder summary = new StringBuilder(1024);

--- a/modules/core/src/main/java/com/illposed/osc/OSCBundle.java
+++ b/modules/core/src/main/java/com/illposed/osc/OSCBundle.java
@@ -87,12 +87,13 @@ public class OSCBundle implements OSCPacket {
 		return timestamp;
 	}
 
+	// Public API
 	/**
 	 * Sets the time the bundle will execute.
 	 * @param timestamp when the bundle should execute, can not be {@code null},
 	 *   but {@code OSCTimeTag64.IMMEDIATE}
 	 */
-	@SuppressWarnings("WeakerAccess") // Public API
+	@SuppressWarnings("WeakerAccess")
 	public void setTimestamp(final OSCTimeTag64 timestamp) {
 
 		checkNonNullTimestamp(timestamp);

--- a/modules/core/src/main/java/com/illposed/osc/OSCMessage.java
+++ b/modules/core/src/main/java/com/illposed/osc/OSCMessage.java
@@ -107,17 +107,19 @@ public class OSCMessage implements OSCPacket {
 		return info;
 	}
 
-	@SuppressWarnings("WeakerAccess") // Public API
+	// Public API
+	@SuppressWarnings("WeakerAccess")
 	public boolean isInfoSet() {
 		return (info != null);
 	}
 
+	// Public API
 	/**
 	 * Sets meta-info about this message.
 	 * This method may only be called if the meta-info has not yet been set.
 	 * @param info the meta-info for this message, may not be {@code null}
 	 */
-	@SuppressWarnings("WeakerAccess") // Public API
+	@SuppressWarnings("WeakerAccess")
 	public void setInfo(final OSCMessageInfo info) {
 
 		if (this.info != null) {
@@ -136,12 +138,13 @@ public class OSCMessage implements OSCPacket {
 		}
 	}
 
+	// Public API
 	/**
 	 * Checks whether a given string is a valid OSC <i>Address Pattern</i>.
 	 * @param address to be checked for validity
 	 * @return true if the supplied string constitutes a valid OSC address
 	 */
-	@SuppressWarnings("WeakerAccess") // Public API
+	@SuppressWarnings("WeakerAccess")
 	public static boolean isValidAddress(final String address) {
 		return (address != null)
 				&& !address.isEmpty()

--- a/modules/core/src/main/java/com/illposed/osc/OSCMessageInfo.java
+++ b/modules/core/src/main/java/com/illposed/osc/OSCMessageInfo.java
@@ -16,10 +16,11 @@ public class OSCMessageInfo {
 
 	private final CharSequence argumentTypeTags;
 
+	// Public API
 	/**
 	 * @param argumentTypeTags the <i>Arguments Type Tags</i> string, for example "iiscdi[fff]h"
 	 */
-	@SuppressWarnings({"WeakerAccess", "SpellCheckingInspection"}) // Public API
+	@SuppressWarnings({"WeakerAccess", "SpellCheckingInspection"})
 	public OSCMessageInfo(final CharSequence argumentTypeTags) {
 		this.argumentTypeTags = argumentTypeTags;
 	}

--- a/modules/core/src/main/java/com/illposed/osc/OSCPacketDispatcher.java
+++ b/modules/core/src/main/java/com/illposed/osc/OSCPacketDispatcher.java
@@ -27,6 +27,7 @@ import java.util.concurrent.TimeUnit;
  */
 public class OSCPacketDispatcher {
 
+	// Public API
 	/**
 	 * Completely arbitrary number of arguments,
 	 * required only due to library internal technical reasons.
@@ -34,7 +35,7 @@ public class OSCPacketDispatcher {
 	 * by refactoring the code.
 	 * XXX refactor-out this arbitrary number
 	 */
-	@SuppressWarnings("WeakerAccess") // Public API
+	@SuppressWarnings("WeakerAccess")
 	public static final int MAX_ARGUMENTS = 64;
 	private static final int DEFAULT_CORE_THREADS = 3;
 	private final ByteBuffer argumentTypesBuffer;
@@ -126,7 +127,8 @@ public class OSCPacketDispatcher {
 		}
 	}
 
-	@SuppressWarnings("WeakerAccess") // Public API
+	// Public API
+	@SuppressWarnings("WeakerAccess")
 	public OSCPacketDispatcher(
 			final OSCSerializerFactory serializerFactory,
 			final ScheduledExecutorService dispatchScheduler)
@@ -154,7 +156,8 @@ public class OSCPacketDispatcher {
 		this.dispatchScheduler = dispatchScheduler;
 	}
 
-	@SuppressWarnings("WeakerAccess") // Public API
+	// Public API
+	@SuppressWarnings("WeakerAccess")
 	public OSCPacketDispatcher(final OSCSerializerFactory serializerFactory) {
 		this(serializerFactory, createDefaultDispatchScheduler());
 	}
@@ -163,7 +166,8 @@ public class OSCPacketDispatcher {
 		this(null);
 	}
 
-	@SuppressWarnings("WeakerAccess") // Public API
+	// Public API
+	@SuppressWarnings("WeakerAccess")
 	public static ScheduledExecutorService createDefaultDispatchScheduler() {
 		return Executors.newScheduledThreadPool(DEFAULT_CORE_THREADS, new DaemonThreadFactory());
 	}
@@ -177,20 +181,22 @@ public class OSCPacketDispatcher {
 		this.alwaysDispatchingImmediately = alwaysDispatchingImmediately;
 	}
 
+	// Public API
 	/**
 	 * Indicates whether we disregard bundle time-stamps for dispatch-scheduling.
 	 * @return {@code true}, if all bundles are dispatched immediately
 	 */
-	@SuppressWarnings("WeakerAccess") // Public API
+	@SuppressWarnings("WeakerAccess")
 	public boolean isAlwaysDispatchingImmediately() {
 		return alwaysDispatchingImmediately;
 	}
 
+	// Public API
 	/**
 	 * Indicates whether we need outgoing messages to have meta-info attached.
 	 * @return {@code true}, if at least one of the registered listeners requires message meta-info
 	 */
-	@SuppressWarnings("WeakerAccess") // Public API
+	@SuppressWarnings("WeakerAccess")
 	public boolean isMetaInfoRequired() {
 		return metaInfoRequired;
 	}
@@ -215,6 +221,7 @@ public class OSCPacketDispatcher {
 		}
 	}
 
+	// Public API
 	/**
 	 * Removes a listener (<i>Method</i> in OSC speak), which will no longer
 	 * be notified of incoming messages.
@@ -222,7 +229,7 @@ public class OSCPacketDispatcher {
 	 * @param messageSelector has to match the registered pair to be removed
 	 * @param listener will no longer receive messages accepted by the selector
 	 */
-	@SuppressWarnings("WeakerAccess") // Public API
+	@SuppressWarnings("WeakerAccess")
 	public void removeListener(
 			final MessageSelector messageSelector,
 			final OSCMessageListener listener)
@@ -241,20 +248,22 @@ public class OSCPacketDispatcher {
 		}
 	}
 
+	// Public API
 	/**
 	 * Adds a listener that will be notified of incoming bad/unrecognized data.
 	 * @param listener will receive chunks of unrecognized data
 	 */
-	@SuppressWarnings("WeakerAccess") // Public API
+	@SuppressWarnings("WeakerAccess")
 	public void addBadDataListener(final OSCBadDataListener listener) {
 		badDataListeners.add(listener);
 	}
 
+	// Public API
 	/**
 	 * Removes a listener that is notified of incoming bad/unrecognized data.
 	 * @param listener will no longer receive chunks of unrecognized data
 	 */
-	@SuppressWarnings("unused") // Public API
+	@SuppressWarnings("unused")
 	public void removeBadDataListener(final OSCBadDataListener listener) {
 		badDataListeners.remove(listener);
 	}
@@ -351,7 +360,8 @@ public class OSCPacketDispatcher {
 		ensureMetaInfo(event.getMessage());
 
 		for (final PacketListener packetListener : packetListeners) {
-			if (packetListener.getSelector().matches(event.getMessage())) { // TODO Maybe also supply the message event instead of only the message?
+			// TODO Maybe also supply the message event instead of only the message?
+			if (packetListener.getSelector().matches(event.getMessage())) {
 				packetListener.getListener().acceptMessage(event);
 			}
 		}

--- a/modules/core/src/main/java/com/illposed/osc/OSCParser.java
+++ b/modules/core/src/main/java/com/illposed/osc/OSCParser.java
@@ -30,21 +30,26 @@ import java.util.Map;
  */
 public class OSCParser {
 
+	// Public API
 	/**
 	 * Number of bytes the raw OSC data stream is aligned to.
 	 */
-	@SuppressWarnings("WeakerAccess") // Public API
+	@SuppressWarnings("WeakerAccess")
 	public static final int ALIGNMENT_BYTES = 4;
-	@SuppressWarnings("WeakerAccess") // Public API
+	// Public API
+	@SuppressWarnings("WeakerAccess")
 	public static final String BUNDLE_START = "#bundle";
 	private static final byte[] BUNDLE_START_BYTES
 			= BUNDLE_START.getBytes(Charset.forName("UTF-8"));
 	private static final String NO_ARGUMENT_TYPES = "";
-	@SuppressWarnings("WeakerAccess") // Public API
+	// Public API
+	@SuppressWarnings("WeakerAccess")
 	public static final byte TYPES_VALUES_SEPARATOR = (byte) ',';
-	@SuppressWarnings("WeakerAccess") // Public API
+	// Public API
+	@SuppressWarnings("WeakerAccess")
 	public static final char TYPE_ARRAY_BEGIN = (byte) '[';
-	@SuppressWarnings("WeakerAccess") // Public API
+	// Public API
+	@SuppressWarnings("WeakerAccess")
 	public static final char TYPE_ARRAY_END = (byte) ']';
 
 	private final Map<Character, ArgumentHandler> identifierToType;
@@ -59,13 +64,14 @@ public class OSCParser {
 		}
 	}
 
+	// Public API
 	/**
 	 * Creates a new parser with all the required ingredients.
 	 * @param identifierToType all of these, and only these arguments will be
 	 *   parsable by this object, that are supported by these handlers
 	 * @param properties see {@link ArgumentHandler#setProperties(java.util.Map)}
 	 */
-	@SuppressWarnings("WeakerAccess") // Public API
+	@SuppressWarnings("WeakerAccess")
 	public OSCParser(
 			final Map<Character, ArgumentHandler> identifierToType,
 			final Map<String, Object> properties)
@@ -98,7 +104,8 @@ public class OSCParser {
 		input.position(input.position() + padding);
 	}
 
-	@SuppressWarnings("unused") // Public API
+	// Public API
+	@SuppressWarnings("unused")
 	public Map<Character, ArgumentHandler> getIdentifierToTypeMapping() {
 		return identifierToType;
 	}

--- a/modules/core/src/main/java/com/illposed/osc/OSCParserFactory.java
+++ b/modules/core/src/main/java/com/illposed/osc/OSCParserFactory.java
@@ -28,12 +28,14 @@ public final class OSCParserFactory {
 		this.identifierToType = new HashMap<>();
 	}
 
-	@SuppressWarnings("WeakerAccess") // Public API
+	// Public API
+	@SuppressWarnings("WeakerAccess")
 	public Map<Character, ArgumentHandler> getIdentifierToTypeMapping() {
 		return Collections.unmodifiableMap(identifierToType);
 	}
 
-	@SuppressWarnings("WeakerAccess") // Public API
+	// Public API
+	@SuppressWarnings("WeakerAccess")
 	public static OSCParserFactory createEmptyFactory() {
 		return new OSCParserFactory();
 	}
@@ -97,6 +99,7 @@ public final class OSCParserFactory {
 		addProperties(properties);
 	}
 
+	// Public API
 	/**
 	 * Adds a new set of properties, extending,
 	 * possibly overriding the current ones.
@@ -106,11 +109,12 @@ public final class OSCParserFactory {
 	 * being created in the future.
 	 * @param additionalProperties the new set of properties to adhere to
 	 */
-	@SuppressWarnings("WeakerAccess") // Public API
+	@SuppressWarnings("WeakerAccess")
 	public void addProperties(final Map<String, Object> additionalProperties) {
 		properties.putAll(additionalProperties);
 	}
 
+	// Public API
 	/**
 	 * Clears all currently stored properties.
 	 * Properties will be propagated to created parsers
@@ -118,17 +122,19 @@ public final class OSCParserFactory {
 	 * This will only have an effect for parsers and argument-handlers
 	 * being created in the future.
 	 */
-	@SuppressWarnings("WeakerAccess") // Public API
+	@SuppressWarnings("WeakerAccess")
 	public void clearProperties() {
 		properties.clear();
 	}
 
-	@SuppressWarnings("unused") // Public API
+	// Public API
+	@SuppressWarnings("unused")
 	public void registerArgumentHandler(final ArgumentHandler argumentHandler) {
 		registerArgumentHandler(argumentHandler, argumentHandler.getDefaultIdentifier());
 	}
 
-	@SuppressWarnings("WeakerAccess") // Public API
+	// Public API
+	@SuppressWarnings("WeakerAccess")
 	public void registerArgumentHandler(
 			final ArgumentHandler argumentHandler,
 			final char typeIdentifier)
@@ -142,12 +148,14 @@ public final class OSCParserFactory {
 		identifierToType.put(typeIdentifier, argumentHandler);
 	}
 
-	@SuppressWarnings("unused") // Public API
+	// Public API
+	@SuppressWarnings("unused")
 	public void unregisterArgumentHandler(final ArgumentHandler argumentHandler) {
 		unregisterArgumentHandler(argumentHandler.getDefaultIdentifier());
 	}
 
-	@SuppressWarnings({"WeakerAccess", "UnusedReturnValue"}) // Public API
+	// Public API
+	@SuppressWarnings({"WeakerAccess", "UnusedReturnValue"})
 	public ArgumentHandler unregisterArgumentHandler(final char typeIdentifier) {
 		return identifierToType.remove(typeIdentifier);
 	}

--- a/modules/core/src/main/java/com/illposed/osc/OSCSerializer.java
+++ b/modules/core/src/main/java/com/illposed/osc/OSCSerializer.java
@@ -150,7 +150,8 @@ public class OSCSerializer {
 				new HashMap<>(properties));
 	}
 
-	@SuppressWarnings({"WeakerAccess", "unused"}) // Public API
+	// Public API
+	@SuppressWarnings({"WeakerAccess", "unused"})
 	public Map<Class, ArgumentHandler> getClassToTypeMapping() {
 		return classToType;
 	}
@@ -164,7 +165,8 @@ public class OSCSerializer {
 		return properties;
 	}
 
-	@SuppressWarnings("WeakerAccess") // Public API
+	// Public API
+	@SuppressWarnings("WeakerAccess")
 	public static byte[] toByteArray(final ByteBuffer buffer) {
 
 		final byte[] bytes = new byte[buffer.remaining()];
@@ -172,12 +174,13 @@ public class OSCSerializer {
 		return bytes;
 	}
 
+	// Public API
 	/**
 	 * Terminates the previously written piece of data with a single {@code (byte) '0'}.
 	 * We always need to terminate with a zero, especially when the stream is already aligned.
 	 * @param output to receive the data-piece termination
 	 */
-	@SuppressWarnings("WeakerAccess") // Public API
+	@SuppressWarnings("WeakerAccess")
 	public static void terminate(final ByteBuffer output) {
 		output.put((byte) 0);
 	}

--- a/modules/core/src/main/java/com/illposed/osc/OSCSerializerFactory.java
+++ b/modules/core/src/main/java/com/illposed/osc/OSCSerializerFactory.java
@@ -32,12 +32,14 @@ public class OSCSerializerFactory {
 		this.argumentHandlers = new LinkedList<>();
 	}
 
-	@SuppressWarnings("WeakerAccess") // Public API
+	// Public API
+	@SuppressWarnings("WeakerAccess")
 	public List<ArgumentHandler> getArgumentHandlers() {
 		return Collections.unmodifiableList(argumentHandlers);
 	}
 
-	@SuppressWarnings("WeakerAccess") // Public API
+	// Public API
+	@SuppressWarnings("WeakerAccess")
 	public static OSCSerializerFactory createEmptyFactory() {
 		return new OSCSerializerFactory();
 	}
@@ -97,6 +99,7 @@ public class OSCSerializerFactory {
 		addProperties(properties);
 	}
 
+	// Public API
 	/**
 	 * Adds a new set of properties, extending,
 	 * possibly overriding the current ones.
@@ -106,11 +109,12 @@ public class OSCSerializerFactory {
 	 * being created in the future.
 	 * @param additionalProperties the new set of properties to adhere to
 	 */
-	@SuppressWarnings("WeakerAccess") // Public API
+	@SuppressWarnings("WeakerAccess")
 	public void addProperties(final Map<String, Object> additionalProperties) {
 		properties.putAll(additionalProperties);
 	}
 
+	// Public API
 	/**
 	 * Clears all currently stored properties.
 	 * Properties will be propagated to created serializers
@@ -118,17 +122,19 @@ public class OSCSerializerFactory {
 	 * This will only have an effect for serializers and argument-handlers
 	 * being created in the future.
 	 */
-	@SuppressWarnings("WeakerAccess") // Public API
+	@SuppressWarnings("WeakerAccess")
 	public void clearProperties() {
 		properties.clear();
 	}
 
-	@SuppressWarnings("WeakerAccess") // Public API
+	// Public API
+	@SuppressWarnings("WeakerAccess")
 	public void registerArgumentHandler(final ArgumentHandler argumentHandler) {
 		argumentHandlers.add(argumentHandler);
 	}
 
-	@SuppressWarnings({"WeakerAccess", "unused"}) // Public API
+	// Public API
+	@SuppressWarnings({"WeakerAccess", "unused"})
 	public void unregisterArgumentHandler(final ArgumentHandler argumentHandler) {
 		argumentHandlers.remove(argumentHandler);
 	}

--- a/modules/core/src/main/java/com/illposed/osc/SerializableByteBuffer.java
+++ b/modules/core/src/main/java/com/illposed/osc/SerializableByteBuffer.java
@@ -15,10 +15,11 @@ import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
+// Public API
 /**
  * Allows to serialize and deserialize a {@link java.nio.ByteBuffer}.
  */
-@SuppressWarnings("WeakerAccess") // Public API
+@SuppressWarnings("WeakerAccess")
 public class SerializableByteBuffer implements Serializable {
 
 	private static final long serialVersionUID = 1L;
@@ -26,12 +27,14 @@ public class SerializableByteBuffer implements Serializable {
 	// mark as transient so this is not serialized by default
 	private transient ByteBuffer buffer;
 
-	@SuppressWarnings("WeakerAccess") // Public API
+	// Public API
+	@SuppressWarnings("WeakerAccess")
 	public SerializableByteBuffer(final ByteBuffer buffer) {
 		this.buffer = buffer;
 	}
 
-	@SuppressWarnings("WeakerAccess") // Public API
+	// Public API
+	@SuppressWarnings("WeakerAccess")
 	public ByteBuffer getBuffer() {
 		return buffer;
 	}

--- a/modules/core/src/main/java/com/illposed/osc/argument/OSCMidiMessage.java
+++ b/modules/core/src/main/java/com/illposed/osc/argument/OSCMidiMessage.java
@@ -23,7 +23,8 @@ public class OSCMidiMessage implements Cloneable, Serializable, Comparable<OSCMi
 	private final byte data1;
 	private final byte data2;
 
-	@SuppressWarnings("WeakerAccess") // Public API
+	// Public API
+	@SuppressWarnings("WeakerAccess")
 	public OSCMidiMessage(final byte portId, final byte status, final byte data1, final byte data2) {
 
 		this.portId = portId;
@@ -36,22 +37,26 @@ public class OSCMidiMessage implements Cloneable, Serializable, Comparable<OSCMi
 		return new byte[] {getPortId(), getStatus(), getData1(), getData2()};
 	}
 
-	@SuppressWarnings("WeakerAccess") // Public API
+	// Public API
+	@SuppressWarnings("WeakerAccess")
 	public byte getPortId() {
 		return portId;
 	}
 
-	@SuppressWarnings("WeakerAccess") // Public API
+	// Public API
+	@SuppressWarnings("WeakerAccess")
 	public byte getStatus() {
 		return status;
 	}
 
-	@SuppressWarnings("WeakerAccess") // Public API
+	// Public API
+	@SuppressWarnings("WeakerAccess")
 	public byte getData1() {
 		return data1;
 	}
 
-	@SuppressWarnings("WeakerAccess") // Public API
+	// Public API
+	@SuppressWarnings("WeakerAccess")
 	public byte getData2() {
 		return data2;
 	}

--- a/modules/core/src/main/java/com/illposed/osc/argument/OSCSymbol.java
+++ b/modules/core/src/main/java/com/illposed/osc/argument/OSCSymbol.java
@@ -21,7 +21,8 @@ public class OSCSymbol implements Cloneable, Serializable, Comparable<OSCSymbol>
 
 	private final String value;
 
-	@SuppressWarnings("WeakerAccess") // Public API
+	// Public API
+	@SuppressWarnings("WeakerAccess")
 	public OSCSymbol(final String value) {
 		this.value = value;
 	}

--- a/modules/core/src/main/java/com/illposed/osc/argument/OSCTimeTag64.java
+++ b/modules/core/src/main/java/com/illposed/osc/argument/OSCTimeTag64.java
@@ -42,12 +42,13 @@ import java.util.Date;
  */
 public class OSCTimeTag64 implements Cloneable, Serializable, Comparable<OSCTimeTag64> {
 
+	// Public API
 	/**
 	 * OSC epoch length in milliseconds.
 	 * An epoch is the maximum range of a 64bit OSC Time-tag,
 	 * which is (uint32_max + 1) * 1000 milliseconds.
 	 */
-	@SuppressWarnings("WeakerAccess") // Public API
+	@SuppressWarnings("WeakerAccess")
 	public static final long EPOCH_LENGTH_JAVA_TIME = 0x100000000L * 1000L;
 	/**
 	 * Start of the first epoch expressed in Java time
@@ -57,16 +58,18 @@ public class OSCTimeTag64 implements Cloneable, Serializable, Comparable<OSCTime
 	 * Dates before this can not be represented with an OSC Time-tag.
 	 */
 	public static final long EPOCH_START_JAVA_TIME_0 = -2208992400000L;
+	// Public API
 	/**
 	 * Start of the current epoch expressed in Java time.
 	 */
-	@SuppressWarnings("WeakerAccess") // Public API
+	@SuppressWarnings("WeakerAccess")
 	public static final long EPOCH_START_JAVA_TIME_CURRENT
 			= findEpochStartJavaTime(new Date().getTime());
+	// Public API
 	/**
 	 * The OSC time-tag with the semantics of "immediately"/"now".
 	 */
-	@SuppressWarnings("WeakerAccess") // Public API
+	@SuppressWarnings("WeakerAccess")
 	public static final long IMMEDIATE_RAW = 0x1L;
 	/**
 	 * The OSC time-tag with the semantics of "immediately"/"now".
@@ -111,17 +114,19 @@ public class OSCTimeTag64 implements Cloneable, Serializable, Comparable<OSCTime
 		return ntpTime;
 	}
 
+	// Public API
 	/**
 	 * Returns the number of whole seconds from the start of the epoch
 	 * of this time-tag.
 	 * @return high-order 32-bit unsigned value representing the "seconds" part
 	 *   of this OSC <i>Time-tag</i>
 	 */
-	@SuppressWarnings("WeakerAccess") // Public API
+	@SuppressWarnings("WeakerAccess")
 	public long getSeconds() {
 		return ntpTime >>> NTP_SECONDS_BITS;
 	}
 
+	// Public API
 	/**
 	 * Returns the fraction of a second from the start of the epoch + seconds
 	 * of this time-tag.
@@ -130,7 +135,7 @@ public class OSCTimeTag64 implements Cloneable, Serializable, Comparable<OSCTime
 	 * @return lower-order 32-bit unsigned value representing the "fraction"
 	 *   part of this OSC <i>Time-tag</i>
 	 */
-	@SuppressWarnings("WeakerAccess") // Public API
+	@SuppressWarnings("WeakerAccess")
 	public long getFraction() {
 		return ntpTime & FILTER_LOWER_32;
 	}

--- a/modules/core/src/main/java/com/illposed/osc/argument/OSCUnsigned.java
+++ b/modules/core/src/main/java/com/illposed/osc/argument/OSCUnsigned.java
@@ -17,20 +17,23 @@ import java.io.Serializable;
  */
 public final class OSCUnsigned implements Cloneable, Serializable, Comparable<OSCUnsigned> {
 
+	// Public API
 	/**
 	 * The number of bytes used to represent an unsigned integer value in binary form.
 	 */
-	@SuppressWarnings("WeakerAccess") // Public API
+	@SuppressWarnings("WeakerAccess")
 	public static final int BYTES = 4;
+	// Public API
 	/**
 	 * A constant holding the minimum value a 32bit unsigned integer can have, 0.
 	 */
-	@SuppressWarnings("WeakerAccess") // Public API
+	@SuppressWarnings("WeakerAccess")
 	public static final OSCUnsigned MIN_VALUE = new OSCUnsigned(0x0L);
+	// Public API
 	/**
 	 * A constant holding the maximum value a 32bit unsigned integer can have, 2^{32}.
 	 */
-	@SuppressWarnings("WeakerAccess") // Public API
+	@SuppressWarnings("WeakerAccess")
 	public static final OSCUnsigned MAX_VALUE = new OSCUnsigned(0xFFFFFFFFL);
 
 	private static final long serialVersionUID = 1L;
@@ -92,7 +95,7 @@ public final class OSCUnsigned implements Cloneable, Serializable, Comparable<OS
 		final long value
 				= ((long) bytes[0] & 0xFF) << (3 * Byte.SIZE)
 				| ((long) bytes[1] & 0xFF) << (2 * Byte.SIZE)
-				| ((long) bytes[2] & 0xFF) << (    Byte.SIZE)
+				| ((long) bytes[2] & 0xFF) << (Byte.SIZE)
 				| ((long) bytes[3] & 0xFF);
 		return valueOf(value);
 	}

--- a/modules/core/src/main/java/com/illposed/osc/argument/handler/BooleanFalseArgumentHandler.java
+++ b/modules/core/src/main/java/com/illposed/osc/argument/handler/BooleanFalseArgumentHandler.java
@@ -19,8 +19,9 @@ public class BooleanFalseArgumentHandler implements ArgumentHandler<Boolean>, Cl
 
 	public static final ArgumentHandler<Boolean> INSTANCE = new BooleanFalseArgumentHandler();
 
+	// Public API
 	/** Allow overriding, but somewhat enforce the ugly singleton. */
-	@SuppressWarnings("WeakerAccess") // Public API
+	@SuppressWarnings("WeakerAccess")
 	protected BooleanFalseArgumentHandler() {
 		// declared only for setting the access level
 	}

--- a/modules/core/src/main/java/com/illposed/osc/argument/handler/BooleanTrueArgumentHandler.java
+++ b/modules/core/src/main/java/com/illposed/osc/argument/handler/BooleanTrueArgumentHandler.java
@@ -19,8 +19,9 @@ public class BooleanTrueArgumentHandler implements ArgumentHandler<Boolean>, Clo
 
 	public static final ArgumentHandler<Boolean> INSTANCE = new BooleanTrueArgumentHandler();
 
+	// Public API
 	/** Allow overriding, but somewhat enforce the ugly singleton. */
-	@SuppressWarnings("WeakerAccess") // Public API
+	@SuppressWarnings("WeakerAccess")
 	protected BooleanTrueArgumentHandler() {
 		// declared only for setting the access level
 	}

--- a/modules/core/src/main/java/com/illposed/osc/argument/handler/ByteArrayBlobArgumentHandler.java
+++ b/modules/core/src/main/java/com/illposed/osc/argument/handler/ByteArrayBlobArgumentHandler.java
@@ -21,8 +21,9 @@ public class ByteArrayBlobArgumentHandler implements ArgumentHandler<byte[]>, Cl
 
 	public static final ArgumentHandler<byte[]> INSTANCE = new ByteArrayBlobArgumentHandler();
 
+	// Public API
 	/** Allow overriding, but somewhat enforce the ugly singleton. */
-	@SuppressWarnings("WeakerAccess") // Public API
+	@SuppressWarnings("WeakerAccess")
 	protected ByteArrayBlobArgumentHandler() {
 		// declared only for setting the access level
 	}

--- a/modules/core/src/main/java/com/illposed/osc/argument/handler/CharArgumentHandler.java
+++ b/modules/core/src/main/java/com/illposed/osc/argument/handler/CharArgumentHandler.java
@@ -19,8 +19,9 @@ public class CharArgumentHandler implements ArgumentHandler<Character>, Cloneabl
 
 	public static final ArgumentHandler<Character> INSTANCE = new CharArgumentHandler();
 
+	// Public API
 	/** Allow overriding, but somewhat enforce the ugly singleton. */
-	@SuppressWarnings("WeakerAccess") // Public API
+	@SuppressWarnings("WeakerAccess")
 	protected CharArgumentHandler() {
 		// declared only for setting the access level
 	}

--- a/modules/core/src/main/java/com/illposed/osc/argument/handler/ColorArgumentHandler.java
+++ b/modules/core/src/main/java/com/illposed/osc/argument/handler/ColorArgumentHandler.java
@@ -20,8 +20,9 @@ public class ColorArgumentHandler implements ArgumentHandler<Color>, Cloneable {
 
 	public static final ArgumentHandler<Color> INSTANCE = new ColorArgumentHandler();
 
+	// Public API
 	/** Allow overriding, but somewhat enforce the ugly singleton. */
-	@SuppressWarnings("WeakerAccess") // Public API
+	@SuppressWarnings("WeakerAccess")
 	protected ColorArgumentHandler() {
 		// declared only for setting the access level
 	}
@@ -52,6 +53,7 @@ public class ColorArgumentHandler implements ArgumentHandler<Color>, Cloneable {
 		return (ColorArgumentHandler) super.clone();
 	}
 
+	// Public API
 	/**
 	 * Converts the argument to an {@code int} by an unsigned conversion.
 	 *
@@ -59,18 +61,19 @@ public class ColorArgumentHandler implements ArgumentHandler<Color>, Cloneable {
 	 * @return the argument converted to {@code int} by an unsigned conversion NOTE Since Java 8,
 	 * one could use Byte#toUnsignedInt
 	 */
-	@SuppressWarnings("WeakerAccess") // Public API
+	@SuppressWarnings("WeakerAccess")
 	public static int toUnsignedInt(final byte signedByte) {
 		return ((int) signedByte) & 0xff;
 	}
 
+	// Public API
 	/**
 	 * Converts the argument to an {@code byte} by a sign introducing conversion.
 	 *
 	 * @param unsignedInt the value to convert to a signed {@code byte}; has to be in range [0, 255]
 	 * @return the argument converted to {@code byte} by a sign introducing conversion
 	 */
-	@SuppressWarnings("WeakerAccess") // Public API
+	@SuppressWarnings("WeakerAccess")
 	public static byte toSignedByte(final int unsignedInt) {
 		return (byte) unsignedInt;
 	}

--- a/modules/core/src/main/java/com/illposed/osc/argument/handler/DateTimeStampArgumentHandler.java
+++ b/modules/core/src/main/java/com/illposed/osc/argument/handler/DateTimeStampArgumentHandler.java
@@ -35,8 +35,9 @@ public class DateTimeStampArgumentHandler implements ArgumentHandler<Date>, Clon
 
 	private Long epochIndicatorTime;
 
+	// Public API
 	/** Allow overriding, but somewhat enforce the ugly singleton. */
-	@SuppressWarnings("WeakerAccess") // Public API
+	@SuppressWarnings("WeakerAccess")
 	protected DateTimeStampArgumentHandler() {
 
 		// now
@@ -53,7 +54,8 @@ public class DateTimeStampArgumentHandler implements ArgumentHandler<Date>, Clon
 		return Date.class;
 	}
 
-	@SuppressWarnings("WeakerAccess") // Public API
+	// Public API
+	@SuppressWarnings("WeakerAccess")
 	public void setEpochIndicatorTime(final Long epochIndicatorTime) {
 		this.epochIndicatorTime = epochIndicatorTime;
 	}

--- a/modules/core/src/main/java/com/illposed/osc/argument/handler/DoubleArgumentHandler.java
+++ b/modules/core/src/main/java/com/illposed/osc/argument/handler/DoubleArgumentHandler.java
@@ -21,8 +21,9 @@ public class DoubleArgumentHandler implements ArgumentHandler<Double>, Cloneable
 
 	public static final ArgumentHandler<Double> INSTANCE = new DoubleArgumentHandler();
 
+	// Public API
 	/** Allow overriding, but somewhat enforce the ugly singleton. */
-	@SuppressWarnings("WeakerAccess") // Public API
+	@SuppressWarnings("WeakerAccess")
 	protected DoubleArgumentHandler() {
 		// declared only for setting the access level
 	}

--- a/modules/core/src/main/java/com/illposed/osc/argument/handler/FloatArgumentHandler.java
+++ b/modules/core/src/main/java/com/illposed/osc/argument/handler/FloatArgumentHandler.java
@@ -21,8 +21,9 @@ public class FloatArgumentHandler implements ArgumentHandler<Float>, Cloneable {
 
 	public static final ArgumentHandler<Float> INSTANCE = new FloatArgumentHandler();
 
+	// Public API
 	/** Allow overriding, but somewhat enforce the ugly singleton. */
-	@SuppressWarnings("WeakerAccess") // Public API
+	@SuppressWarnings("WeakerAccess")
 	protected FloatArgumentHandler() {
 		// declared only for setting the access level
 	}

--- a/modules/core/src/main/java/com/illposed/osc/argument/handler/ImpulseArgumentHandler.java
+++ b/modules/core/src/main/java/com/illposed/osc/argument/handler/ImpulseArgumentHandler.java
@@ -20,8 +20,9 @@ public class ImpulseArgumentHandler implements ArgumentHandler<OSCImpulse>, Clon
 
 	public static final ArgumentHandler<OSCImpulse> INSTANCE = new ImpulseArgumentHandler();
 
+	// Public API
 	/** Allow overriding, but somewhat enforce the ugly singleton. */
-	@SuppressWarnings("WeakerAccess") // Public API
+	@SuppressWarnings("WeakerAccess")
 	protected ImpulseArgumentHandler() {
 		// declared only for setting the access level
 	}

--- a/modules/core/src/main/java/com/illposed/osc/argument/handler/IntegerArgumentHandler.java
+++ b/modules/core/src/main/java/com/illposed/osc/argument/handler/IntegerArgumentHandler.java
@@ -17,15 +17,17 @@ import java.util.Map;
  */
 public class IntegerArgumentHandler implements ArgumentHandler<Integer>, Cloneable {
 
+	// Public API
 	/**
 	 * The number of bytes used to represent this type in an OSC byte array (4).
 	 */
-	@SuppressWarnings("WeakerAccess") // Public API
+	@SuppressWarnings("WeakerAccess")
 	public static final int BYTES = Integer.SIZE / Byte.SIZE;
 	public static final ArgumentHandler<Integer> INSTANCE = new IntegerArgumentHandler();
 
+	// Public API
 	/** Allow overriding, but somewhat enforce the ugly singleton. */
-	@SuppressWarnings("WeakerAccess") // Public API
+	@SuppressWarnings("WeakerAccess")
 	protected IntegerArgumentHandler() {
 		// declared only for setting the access level
 	}

--- a/modules/core/src/main/java/com/illposed/osc/argument/handler/LongArgumentHandler.java
+++ b/modules/core/src/main/java/com/illposed/osc/argument/handler/LongArgumentHandler.java
@@ -17,15 +17,17 @@ import java.util.Map;
  */
 public class LongArgumentHandler implements ArgumentHandler<Long>, Cloneable {
 
+	// Public API
 	/**
 	 * The number of bytes used to represent this type in an OSC byte array (8).
 	 */
-	@SuppressWarnings("WeakerAccess") // Public API
+	@SuppressWarnings("WeakerAccess")
 	public static final int BYTES = Long.SIZE / Byte.SIZE;
 	public static final ArgumentHandler<Long> INSTANCE = new LongArgumentHandler();
 
+	// Public API
 	/** Allow overriding, but somewhat enforce the ugly singleton. */
-	@SuppressWarnings("WeakerAccess") // Public API
+	@SuppressWarnings("WeakerAccess")
 	protected LongArgumentHandler() {
 		// declared only for setting the access level
 	}

--- a/modules/core/src/main/java/com/illposed/osc/argument/handler/MidiMessageArgumentHandler.java
+++ b/modules/core/src/main/java/com/illposed/osc/argument/handler/MidiMessageArgumentHandler.java
@@ -20,8 +20,9 @@ public class MidiMessageArgumentHandler implements ArgumentHandler<OSCMidiMessag
 
 	public static final ArgumentHandler<OSCMidiMessage> INSTANCE = new MidiMessageArgumentHandler();
 
+	// Public API
 	/** Allow overriding, but somewhat enforce the ugly singleton. */
-	@SuppressWarnings("WeakerAccess") // Public API
+	@SuppressWarnings("WeakerAccess")
 	protected MidiMessageArgumentHandler() {
 		// declared only for setting the access level
 	}

--- a/modules/core/src/main/java/com/illposed/osc/argument/handler/NullArgumentHandler.java
+++ b/modules/core/src/main/java/com/illposed/osc/argument/handler/NullArgumentHandler.java
@@ -19,8 +19,9 @@ public class NullArgumentHandler implements ArgumentHandler<Object>, Cloneable {
 
 	public static final ArgumentHandler<Object> INSTANCE = new NullArgumentHandler();
 
+	// Public API
 	/** Allow overriding, but somewhat enforce the ugly singleton. */
-	@SuppressWarnings("WeakerAccess") // Public API
+	@SuppressWarnings("WeakerAccess")
 	protected NullArgumentHandler() {
 		// declared only for setting the access level
 	}

--- a/modules/core/src/main/java/com/illposed/osc/argument/handler/StringArgumentHandler.java
+++ b/modules/core/src/main/java/com/illposed/osc/argument/handler/StringArgumentHandler.java
@@ -22,35 +22,40 @@ import java.util.Map;
  */
 public class StringArgumentHandler implements ArgumentHandler<String>, Cloneable {
 
-	@SuppressWarnings("WeakerAccess") // Public API
+	// Public API
+	@SuppressWarnings("WeakerAccess")
 	public static final char DEFAULT_IDENTIFIER = 's';
 	public static final String PROP_NAME_CHARSET = "charset";
 
 	private Charset charset;
 
-	@SuppressWarnings("WeakerAccess") // Public API
+	// Public API
+	@SuppressWarnings("WeakerAccess")
 	public StringArgumentHandler(final Charset charset) {
 		this.charset = charset;
 	}
-	@SuppressWarnings("WeakerAccess") // Public API
+	// Public API
+	@SuppressWarnings("WeakerAccess")
 	public StringArgumentHandler() {
 		this(Charset.defaultCharset());
 	}
 
+	// Public API
 	/**
 	 * Returns the character-set used to encode and decode string arguments.
 	 * @return the currently used character-encoding-set
 	 */
-	@SuppressWarnings("unused") // Public API
+	@SuppressWarnings("unused")
 	public Charset getCharset() {
 		return charset;
 	}
 
+	// Public API
 	/**
 	 * Sets the character-set used to encode and decode string arguments.
 	 * @param charset the new character-encoding-set
 	 */
-	@SuppressWarnings("WeakerAccess") // Public API
+	@SuppressWarnings("WeakerAccess")
 	public void setCharset(final Charset charset) {
 		this.charset = charset;
 	}

--- a/modules/core/src/main/java/com/illposed/osc/argument/handler/SymbolArgumentHandler.java
+++ b/modules/core/src/main/java/com/illposed/osc/argument/handler/SymbolArgumentHandler.java
@@ -19,17 +19,20 @@ import java.util.Map;
  */
 public class SymbolArgumentHandler implements ArgumentHandler<OSCSymbol>, Cloneable {
 
-	@SuppressWarnings("WeakerAccess") // Public API
+	// Public API
+	@SuppressWarnings("WeakerAccess")
 	public static final char DEFAULT_IDENTIFIER = 'S';
 
 	private final StringArgumentHandler stringArgumentHandler;
 
-	@SuppressWarnings("WeakerAccess") // Public API
+	// Public API
+	@SuppressWarnings("WeakerAccess")
 	public SymbolArgumentHandler() {
 		this.stringArgumentHandler = new StringArgumentHandler();
 	}
 
-	@SuppressWarnings("unused") // Public API
+	// Public API
+	@SuppressWarnings("unused")
 	public StringArgumentHandler getInternalStringArgumentHandler() {
 		return stringArgumentHandler;
 	}

--- a/modules/core/src/main/java/com/illposed/osc/argument/handler/TimeTag64ArgumentHandler.java
+++ b/modules/core/src/main/java/com/illposed/osc/argument/handler/TimeTag64ArgumentHandler.java
@@ -22,8 +22,9 @@ public class TimeTag64ArgumentHandler implements ArgumentHandler<OSCTimeTag64>, 
 
 	public static final ArgumentHandler<OSCTimeTag64> INSTANCE = new TimeTag64ArgumentHandler();
 
+	// Public API
 	/** Allow overriding, but somewhat enforce the ugly singleton. */
-	@SuppressWarnings("WeakerAccess") // Public API
+	@SuppressWarnings("WeakerAccess")
 	protected TimeTag64ArgumentHandler() {
 		// declared only for setting the access level
 	}

--- a/modules/core/src/main/java/com/illposed/osc/argument/handler/UnsignedIntegerArgumentHandler.java
+++ b/modules/core/src/main/java/com/illposed/osc/argument/handler/UnsignedIntegerArgumentHandler.java
@@ -20,8 +20,9 @@ public class UnsignedIntegerArgumentHandler implements ArgumentHandler<OSCUnsign
 
 	public static final ArgumentHandler<OSCUnsigned> INSTANCE = new UnsignedIntegerArgumentHandler();
 
+	// Public API
 	/** Allow overriding, but somewhat enforce the ugly singleton. */
-	@SuppressWarnings("WeakerAccess") // Public API
+	@SuppressWarnings("WeakerAccess")
 	protected UnsignedIntegerArgumentHandler() {
 		// declared only for setting the access level
 	}

--- a/modules/core/src/main/java/com/illposed/osc/messageselector/CombinedMessageSelector.java
+++ b/modules/core/src/main/java/com/illposed/osc/messageselector/CombinedMessageSelector.java
@@ -23,15 +23,19 @@ public class CombinedMessageSelector implements MessageSelector {
 				return (matches1 && matches2);
 			}
 		},
-		@SuppressWarnings("unused") // Public API
-		OR {
+		// Public API
+		@SuppressWarnings("unused")
+		OR
+		{
 			@Override
 			public boolean matches(final boolean matches1, final boolean matches2) {
 				return (matches1 || matches2);
 			}
 		},
-		@SuppressWarnings("unused") // Public API
-		XOR {
+		// Public API
+		@SuppressWarnings("unused")
+		XOR
+		{
 			@Override
 			public boolean matches(final boolean matches1, final boolean matches2) {
 				return ((matches1 && !matches2) || (!matches1 && matches2));
@@ -45,7 +49,8 @@ public class CombinedMessageSelector implements MessageSelector {
 	private final MessageSelector selector2;
 	private final LogicOperator logicOperator;
 
-	@SuppressWarnings("WeakerAccess") // Public API
+	// Public API
+	@SuppressWarnings("WeakerAccess")
 	public CombinedMessageSelector(
 			final MessageSelector selector1,
 			final MessageSelector selector2,
@@ -56,7 +61,8 @@ public class CombinedMessageSelector implements MessageSelector {
 		this.logicOperator = logicOperator;
 	}
 
-	@SuppressWarnings("WeakerAccess") // Public API
+	// Public API
+	@SuppressWarnings("WeakerAccess")
 	public CombinedMessageSelector(
 			final MessageSelector selector1,
 			final MessageSelector selector2)

--- a/modules/core/src/main/java/com/illposed/osc/messageselector/JavaRegexAddressMessageSelector.java
+++ b/modules/core/src/main/java/com/illposed/osc/messageselector/JavaRegexAddressMessageSelector.java
@@ -19,7 +19,8 @@ public class JavaRegexAddressMessageSelector implements MessageSelector {
 
 	private final Pattern selector;
 
-	@SuppressWarnings("WeakerAccess") // Public API
+	// Public API
+	@SuppressWarnings("WeakerAccess")
 	public JavaRegexAddressMessageSelector(final Pattern selector) {
 		this.selector = selector;
 	}

--- a/modules/core/src/main/java/com/illposed/osc/messageselector/JavaRegexTypeTagsMessageSelector.java
+++ b/modules/core/src/main/java/com/illposed/osc/messageselector/JavaRegexTypeTagsMessageSelector.java
@@ -19,17 +19,20 @@ public class JavaRegexTypeTagsMessageSelector implements MessageSelector {
 
 	private final Pattern selector;
 
-	@SuppressWarnings("WeakerAccess") // Public API
+	// Public API
+	@SuppressWarnings("WeakerAccess")
 	public JavaRegexTypeTagsMessageSelector(final Pattern selector) {
 		this.selector = selector;
 	}
 
-	@SuppressWarnings("unused") // Public API
+	// Public API
+	@SuppressWarnings("unused")
 	public JavaRegexTypeTagsMessageSelector(final String selectorRegex) {
 		this(Pattern.compile(selectorRegex));
 	}
 
-	@SuppressWarnings("unused") // Public API
+	// Public API
+	@SuppressWarnings("unused")
 	public static MessageSelector createAddressAndTypeTagsSelector(
 			final Pattern addressSelector,
 			final Pattern typeTagsSelector)

--- a/modules/core/src/main/java/com/illposed/osc/messageselector/OSCPatternAddressMessageSelector.java
+++ b/modules/core/src/main/java/com/illposed/osc/messageselector/OSCPatternAddressMessageSelector.java
@@ -190,6 +190,7 @@ public class OSCPatternAddressMessageSelector implements MessageSelector {
 		return (api == messageAddressParts.size());
 	}
 
+	// Public API
 	/**
 	 * Tries to match an OSC <i>Address Pattern</i> part to a part of
 	 * a selector.
@@ -200,7 +201,7 @@ public class OSCPatternAddressMessageSelector implements MessageSelector {
 	 * @param p pattern part
 	 * @return true if the address part matches, false otherwise
 	 */
-	@SuppressWarnings("WeakerAccess") // Public API
+	@SuppressWarnings("WeakerAccess")
 	public static boolean matches(final String str, final String p) {
 
 		boolean negate;

--- a/modules/core/src/main/java/com/illposed/osc/messageselector/OSCPatternTypeTagsMessageSelector.java
+++ b/modules/core/src/main/java/com/illposed/osc/messageselector/OSCPatternTypeTagsMessageSelector.java
@@ -20,12 +20,14 @@ public class OSCPatternTypeTagsMessageSelector implements MessageSelector {
 
 	private final String selector;
 
-	@SuppressWarnings("WeakerAccess") // Public API
+	// Public API
+	@SuppressWarnings("WeakerAccess")
 	public OSCPatternTypeTagsMessageSelector(final String selector) {
 		this.selector = selector;
 	}
 
-	@SuppressWarnings("unused") // Public API
+	// Public API
+	@SuppressWarnings("unused")
 	public static MessageSelector createAddressAndTypeTagsSelector(
 			final String addressSelector,
 			final String typeTagsSelector)

--- a/modules/core/src/main/java/com/illposed/osc/transport/udp/OSCPortIn.java
+++ b/modules/core/src/main/java/com/illposed/osc/transport/udp/OSCPortIn.java
@@ -46,11 +46,12 @@ import java.nio.channels.DatagramChannel;
  */
 public class OSCPortIn extends OSCPort implements Runnable {
 
+	// Public API
 	/**
 	 * Buffers were 1500 bytes in size, but were increased to 1536, as this is a common MTU,
 	 * and then increased to 65507, as this is the maximum incoming datagram data size.
 	 */
-	@SuppressWarnings("WeakerAccess") // Public API
+	@SuppressWarnings("WeakerAccess")
 	public static final int BUFFER_SIZE = 65507;
 
 	private volatile boolean listening;
@@ -189,10 +190,11 @@ public class OSCPortIn extends OSCPort implements Runnable {
 		}
 	}
 
+	// Public API
 	/**
 	 * Start listening for incoming OSCPackets
 	 */
-	@SuppressWarnings("WeakerAccess") // Public API
+	@SuppressWarnings("WeakerAccess")
 	public void startListening() {
 
 		// NOTE This is not thread-save
@@ -205,10 +207,11 @@ public class OSCPortIn extends OSCPort implements Runnable {
 		}
 	}
 
+	// Public API
 	/**
 	 * Stop listening for incoming OSCPackets
 	 */
-	@SuppressWarnings("WeakerAccess") // Public API
+	@SuppressWarnings("WeakerAccess")
 	public void stopListening() {
 
 		listening = false;
@@ -222,25 +225,28 @@ public class OSCPortIn extends OSCPort implements Runnable {
 		}
 	}
 
+	// Public API
 	/**
 	 * Is this port listening for packets?
 	 * @return true if this port is in listening mode
 	 */
-	@SuppressWarnings("WeakerAccess") // Public API
+	@SuppressWarnings("WeakerAccess")
 	public boolean isListening() {
 		return listening;
 	}
 
+	// Public API
 	/**
 	 * Is this port listening for packets in daemon mode?
 	 * @see #setDaemonListener
 	 * @return <code>true</code> if this ports listening thread is/would be in daemon mode
 	 */
-	@SuppressWarnings({"WeakerAccess", "unused"}) // Public API
+	@SuppressWarnings({"WeakerAccess", "unused"})
 	public boolean isDaemonListener() {
 		return daemonListener;
 	}
 
+	// Public API
 	/**
 	 * Set whether this port should be listening for packets in daemon mode.
 	 * The Java Virtual Machine exits when the only threads running are all daemon threads.
@@ -251,7 +257,7 @@ public class OSCPortIn extends OSCPort implements Runnable {
 	 * @see java.lang.Thread#setDaemon(boolean)
 	 * @param daemonListener whether this ports listening thread should be in daemon mode
 	 */
-	@SuppressWarnings("WeakerAccess") // Public API
+	@SuppressWarnings("WeakerAccess")
 	public void setDaemonListener(final boolean daemonListener) {
 
 		if (isListening()) {
@@ -260,24 +266,26 @@ public class OSCPortIn extends OSCPort implements Runnable {
 		this.daemonListener = daemonListener;
 	}
 
+	// Public API
 	/**
 	 * Whether this port continues listening and throws
 	 * a {@link OSCParseException} after receiving a bad packet.
 	 * @return <code>true</code> if this port will continue listening
 	 *   after a parse exception
 	 */
-	@SuppressWarnings("WeakerAccess") // Public API
+	@SuppressWarnings("WeakerAccess")
 	public boolean isResilient() {
 		return resilient;
 	}
 
+	// Public API
 	/**
 	 * Set whether this port continues listening and throws
 	 * a {@link OSCParseException} after receiving a bad packet.
 	 * @param resilient whether this port should continue listening
 	 *   after a parse exception
 	 */
-	@SuppressWarnings("WeakerAccess") // Public API
+	@SuppressWarnings("WeakerAccess")
 	public void setResilient(final boolean resilient) {
 		this.resilient = resilient;
 	}
@@ -313,7 +321,8 @@ public class OSCPortIn extends OSCPort implements Runnable {
 		return rep.toString();
 	}
 
-	@SuppressWarnings("WeakerAccess") // Public API
+	// Public API
+	@SuppressWarnings("WeakerAccess")
 	public OSCPacketDispatcher getDispatcher() {
 		return dispatcher;
 	}

--- a/modules/parent/pom.xml
+++ b/modules/parent/pom.xml
@@ -9,8 +9,8 @@
 		<project.build.encoding>UTF-8</project.build.encoding>
 		<project.build.sourceEncoding>${project.build.encoding}</project.build.sourceEncoding>
 		<project.build.resourceEncoding>${project.build.encoding}</project.build.resourceEncoding>
-		<java.old.version>7</java.old.version>
-		<java.old.home>${env.JAVA_7_HOME}</java.old.home>
+		<java.old.version>8</java.old.version>
+		<java.old.home>${env.JAVA_8_HOME}</java.old.home>
 		<!-- NOTE This works for reactor/aggregation & child module builds. -->
 		<root.basedir>${project.basedir}/../parent</root.basedir>
 	</properties>
@@ -129,7 +129,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>findbugs-maven-plugin</artifactId>
-				<version>2.5.5</version> <!-- NOTE 2.5.5 is the latest version still compiled with Java 1.6 -->
+				<version>3.0.5</version> <!-- NOTE 2.5.5 is the latest version still compiled with Java 1.6 -->
 			</plugin>
 
 			<plugin>
@@ -294,7 +294,7 @@
 				<plugin>
 					<groupId>org.codehaus.mojo</groupId>
 					<artifactId>findbugs-maven-plugin</artifactId>
-					<version>2.5.5</version> <!-- NOTE 2.5.5 is the latest version still compiled with Java 1.6 -->
+					<version>3.0.5</version> <!-- NOTE 2.5.5 is the latest version still compiled with Java 1.6 -->
 				</plugin>
 			</plugins>
 		</pluginManagement>
@@ -350,7 +350,7 @@
 					<plugin>
 						<groupId>org.codehaus.mojo</groupId>
 						<artifactId>cobertura-maven-plugin</artifactId>
-						<version>2.7</version>
+						<version>2.6</version>
 					</plugin>
 
 					<!--<plugin>


### PR DESCRIPTION
See discussion in #31. I thought I would submit a PR for the fixes I've done so far, working towards getting `mvn install` to work on the `develop` branch. I'm using Java 8.

This PR includes the `java8` branch, which fixes the "Unable to get XClass for ..." errors.

findbugs still found one bug which causes `mvn install` to fail:

```
[INFO] --- findbugs-maven-plugin:3.0.5:check (default) @ javaosc-core ---
[INFO] BugInstance size is 1
[INFO] Error size is 0
[INFO] Total bugs: 1
[INFO] Class com.illposed.osc.OSCMessageEvent defines non-transient non-serializable instance field message [com.illposed.osc.OSCMessageEvent] In OSCMessageEvent.java SE_BAD_FIELD
```

I'm punting on fixing that on this branch. On the up side, I am able to get `mvn install` to succeed if I temporarily remove the fixbugs plugin from the pom.xml, so it isn't really blocking me at this point.