### PR TITLE
Added broadcast support to OSC ports

### DIFF
--- a/modules/core/src/main/java/com/illposed/osc/transport/udp/OSCPort.java
+++ b/modules/core/src/main/java/com/illposed/osc/transport/udp/OSCPort.java
@@ -63,6 +63,7 @@ public class OSCPort {
 		this.channel = tmpChannel;
 
 		this.channel.setOption(StandardSocketOptions.SO_REUSEADDR, true);
+		this.channel.setOption(StandardSocketOptions.SO_BROADCAST, true);
 		this.channel.socket().bind(local);
 	}
 

--- a/modules/core/src/test/java/com/illposed/osc/transport/udp/OSCPortTest.java
+++ b/modules/core/src/test/java/com/illposed/osc/transport/udp/OSCPortTest.java
@@ -437,6 +437,19 @@ public class OSCPortTest {
 	}
 
 	@Test
+	public void testReceivingBroadcast() throws Exception {
+		sender.close();
+
+		// make sure the old receiver is gone for good
+		Thread.sleep(WAIT_FOR_SOCKET_CLOSE);
+
+		InetAddress broadcastAddress = InetAddress.getByName("255.255.255.255");
+		sender = new OSCPortOut(broadcastAddress);
+
+		testReceiving();
+	}
+
+	@Test
 	public void testStart() throws Exception {
 
 		OSCMessage message = new OSCMessage("/sc/stop");


### PR DESCRIPTION
As already mentioned in #44, it is necessary to enable the `SO_BROADCAST ` option to allow the JVM to send broadcast messages. I have added this option nearby the `SO_REUSEADDR` and created a basic test case for it (an tested it of course).