### PR TITLE
Allow sending and receiving messages over the same UDP socket

### DIFF
--- a/modules/core/src/main/java/com/illposed/osc/transport/OSCPort.java
+++ b/modules/core/src/main/java/com/illposed/osc/transport/OSCPort.java
@@ -70,6 +70,17 @@ public class OSCPort {
 		this(local, remote, serializerAndParserBuilder, NetworkProtocol.UDP);
 	}
 
+	protected OSCPort(
+		final Transport transport)
+	{
+		if (transport == null) {
+			throw new IllegalStateException(
+				"Can not use NULL as transport"
+			);
+		}
+		this.transport = transport;
+	}
+
 	public Transport getTransport() {
 		return transport;
 	}

--- a/modules/core/src/main/java/com/illposed/osc/transport/OSCPortIn.java
+++ b/modules/core/src/main/java/com/illposed/osc/transport/OSCPortIn.java
@@ -87,6 +87,28 @@ public class OSCPortIn extends OSCPort implements Runnable {
 	}
 
 	/**
+	 * Create an OSC-Port that uses a concrete {@code transport} given
+	 * as parameter and with {@link #isResilient() resilient} set to true.
+	 * One must make sure that the appropriate connection
+	 * has already been set up before using this instance, meaning
+	 * that local and remote address are set correctly.
+	 * @param transport the transport used for receiving OSC packets
+	 * @param packetListeners to handle received and serialized OSC packets
+	 * @throws IOException if we fail to bind a channel to the local address
+	 */
+	public OSCPortIn(
+		final Transport transport,
+		final List<OSCPacketListener> packetListeners)
+	{
+		super(transport);
+
+		this.listening = false;
+		this.daemonListener = true;
+		this.resilient = true;
+		this.packetListeners = packetListeners;
+	}
+
+	/**
 	 * Create an OSC-Port that listens on the given local socket for packets from {@code remote},
 	 * using a parser created with the given factory,
 	 * and with {@link #isResilient() resilient} set to true.

--- a/modules/core/src/main/java/com/illposed/osc/transport/OSCPortInBuilder.java
+++ b/modules/core/src/main/java/com/illposed/osc/transport/OSCPortInBuilder.java
@@ -24,6 +24,7 @@ public class OSCPortInBuilder {
 	private SocketAddress local;
 	private SocketAddress remote;
 	private NetworkProtocol networkProtocol = NetworkProtocol.UDP;
+	private Transport transport;
 
 	private OSCPacketListener addDefaultPacketListener() {
 		if (packetListeners == null) {
@@ -37,6 +38,33 @@ public class OSCPortInBuilder {
 	}
 
 	public OSCPortIn build() throws IOException {
+
+		if (packetListeners == null) {
+			addDefaultPacketListener();
+		}
+
+		// If transport is set, other settings cannot be used
+		if (transport != null) {
+			if (remote != null) {
+				throw new IllegalArgumentException(
+					"Cannot use remote socket address / port in conjunction with transport object.");
+			}
+
+			if (local != null) {
+				throw new IllegalArgumentException(
+					"Cannot use local socket address / port in conjunction with transport object.");
+			}
+
+			if (parserBuilder != null) {
+				throw new IllegalArgumentException(
+					"Cannot use parserBuilder in conjunction with transport object.");
+			}
+
+			return new OSCPortIn(
+				transport, packetListeners
+			);
+		}
+
 		if (local == null) {
 			throw new IllegalArgumentException(
 				"Missing local socket address / port.");
@@ -48,10 +76,6 @@ public class OSCPortInBuilder {
 
 		if (parserBuilder == null) {
 			parserBuilder = new OSCSerializerAndParserBuilder();
-		}
-
-		if (packetListeners == null) {
-			addDefaultPacketListener();
 		}
 
 		return new OSCPortIn(
@@ -94,6 +118,11 @@ public class OSCPortInBuilder {
 
 	public OSCPortInBuilder setNetworkProtocol(final NetworkProtocol protocol) {
 		networkProtocol = protocol;
+		return this;
+	}
+
+	public OSCPortInBuilder setTransport(final Transport networkTransport) {
+		transport = networkTransport;
 		return this;
 	}
 

--- a/modules/core/src/main/java/com/illposed/osc/transport/OSCPortOut.java
+++ b/modules/core/src/main/java/com/illposed/osc/transport/OSCPortOut.java
@@ -109,6 +109,19 @@ public class OSCPortOut extends OSCPort {
 	}
 
 	/**
+	 * Creates an OSC-Port that sends to a remote host from the specified given
+	 * {@code transport} that was previously created using appropriate local
+	 * and remote addresses, network protocol, and serializers.
+	 * @param transport the transport used for sending OSC packets
+	 * @throws IOException if we fail to bind a channel to the local address
+	 */
+	public OSCPortOut(
+		final Transport transport)
+	{
+		super(transport);
+	}
+
+	/**
 	 * Converts and sends an OSC packet (message or bundle) to the remote address.
 	 * @param packet the bundle or message to be converted and sent
 	 * @throws IOException if a socket I/O error occurs while sending

--- a/modules/core/src/main/java/com/illposed/osc/transport/OSCPortOutBuilder.java
+++ b/modules/core/src/main/java/com/illposed/osc/transport/OSCPortOutBuilder.java
@@ -17,8 +17,32 @@ public class OSCPortOutBuilder {
 	private SocketAddress remote;
 	private SocketAddress local;
 	private NetworkProtocol networkProtocol = NetworkProtocol.UDP;
+	private Transport transport;
 
 	public OSCPortOut build() throws IOException {
+
+		// If transport is set, other settings cannot be used
+		if (transport != null) {
+			if (remote != null) {
+				throw new IllegalArgumentException(
+					"Cannot use remote socket address / port in conjunction with transport.");
+			}
+
+			if (local != null) {
+				throw new IllegalArgumentException(
+					"Cannot use local socket address / port in conjunction with transport.");
+			}
+
+			if (serializerBuilder != null) {
+				throw new IllegalArgumentException(
+					"Cannot use serializerBuilder in conjunction with transport.");
+			}
+
+			return new OSCPortOut(
+				transport
+			);
+		}
+
 		if (remote == null) {
 			throw new IllegalArgumentException(
 				"Missing remote socket address / port.");
@@ -72,6 +96,11 @@ public class OSCPortOutBuilder {
 
 	public OSCPortOutBuilder setNetworkProtocol(final NetworkProtocol protocol) {
 		networkProtocol = protocol;
+		return this;
+	}
+
+	public OSCPortOutBuilder setTransport(final Transport networkTransport) {
+		transport = networkTransport;
 		return this;
 	}
 }

--- a/modules/core/src/main/java/com/illposed/osc/transport/udp/UDPTransport.java
+++ b/modules/core/src/main/java/com/illposed/osc/transport/udp/UDPTransport.java
@@ -24,7 +24,9 @@ import java.nio.channels.DatagramChannel;
 
 /**
  * A {@link Transport} implementation for sending and receiving OSC packets over
- * a network via UDP.
+ * a network via UDP. This implementation uses separate ByteBuffers for sending
+ * and receiving, making it possible to use the same UDP socket for sending packets
+ * and listening simultaneously.
  */
 public class UDPTransport implements Transport {
 
@@ -34,8 +36,8 @@ public class UDPTransport implements Transport {
 	 * incoming datagram data size.
 	 */
 	public static final int BUFFER_SIZE = 65507;
-	private final ByteBuffer buffer = ByteBuffer.allocate(BUFFER_SIZE);
-
+	private final ByteBuffer sendBuffer = ByteBuffer.allocate(BUFFER_SIZE);
+	private final ByteBuffer receiveBuffer = ByteBuffer.allocate(BUFFER_SIZE);
 	private final SocketAddress local;
 	private final SocketAddress remote;
 	private final DatagramChannel channel;
@@ -131,12 +133,12 @@ public class UDPTransport implements Transport {
 
 	@Override
 	public void send(final OSCPacket packet) throws IOException, OSCSerializeException {
-		oscChannel.send(buffer, packet, remote);
+		oscChannel.send(sendBuffer, packet, remote);
 	}
 
 	@Override
 	public OSCPacket receive() throws IOException, OSCParseException {
-		return oscChannel.read(buffer);
+		return oscChannel.read(receiveBuffer);
 	}
 
 	@Override


### PR DESCRIPTION
This extension addresses the following issue: https://github.com/hoijui/JavaOSC/issues/40

That allows bi-directional communication to my Behringer X32 console. Explanation:

1. A JavaOSC Client application uses e.g. IP address 192.168.0.1 with UDP port 1234 as local port, and IP address 192.168.0.2 with UDP port 10023 as remote port on the X32
2. Once X32 receives the packet on port 10023, the response will immediately sent back to the exact sender, that means 192.168.0.1:1234
3. JavaOSC must then read from the exact same socket the it used for sending. Otherwise the datagram will not be accessible by JavaOSC.

With the original implementation, it was of couse possible to use the same input UDP port as the output UDP port, but unfortunately, at least on OSX, it is not possible to create two UDP sockets for sending and receiving on the same port. Therefore I extended the OSCPortOut to accept a "Transport" object in its constructor, which can be retrieved from the OSCPortIn object. Additionally, UDPTransport had to be changed to use two ByteBuffers, one for sending, the other one for receiving. Otherwise we will corrupt receive/response data on the fly. This should not make any issues, as the 

At least this PR works for me since for a few months now. Hope it will meet the quality standards. Please let me know!
