### PR TITLE
Enable logging in ConsoleEchoServer

### DIFF
--- a/modules/core/pom.xml
+++ b/modules/core/pom.xml
@@ -118,19 +118,19 @@ SPDX-License-Identifier: Unlicense
 			<artifactId>junit-jupiter</artifactId>
 			<scope>test</scope>
 		</dependency>
-
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>log4j-over-slf4j</artifactId>
+			<version>2.0.13</version>
+		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-ext</artifactId>
-		</dependency>
+
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-simple</artifactId>
-			<scope>test</scope>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
I tried to run console server, but I see this 
```
SLF4J(W): No SLF4J providers were found.
SLF4J(W): Defaulting to no-operation (NOP) logger implementation
SLF4J(W): See https://www.slf4j.org/codes.html#noProviders for further details.
```

without logging it is for my test purpose pointless, so I made it work with given change. 
Now it starts with

```
[main] INFO com.illposed.osc.ConsoleEchoServer - # Listening for OSC Packets via UDPTransport: local=0.0.0.0/0.0.0.0:5005, remote=/0.0.0.0:0 ...
```