### PR TITLE
Add rudimentary PLH support

### DIFF
--- a/modules/core/src/main/java/com/illposed/osc/OSCSerializer.java
+++ b/modules/core/src/main/java/com/illposed/osc/OSCSerializer.java
@@ -246,6 +246,28 @@ public class OSCSerializer {
 	private void write(final OSCMessage message) throws OSCSerializeException {
 		writeAddress(message);
 		writeArguments(message);
+		if (properties.get("networkProtocol") == NetworkProtocol.TCP) {
+			writePLH();
+		}
+	}
+
+	/**
+	 * Serializes a packet length header. Call this after writing the message and arguments.
+	 * @throws OSCSerializeException if the message failed to serialize
+	 */
+	private void writePLH() throws OSCSerializeException {
+		byte[] rawOutput = output.toByteArray();
+		int length = rawOutput.length;
+		byte[] newOutput = new byte[4 + length];
+		ByteBuffer.wrap(newOutput).putInt(length); // add the length
+		ByteBuffer.wrap(newOutput, 4, length).put(rawOutput); // add the message content
+
+		output.clear();
+		output.put(newOutput);
+
+		if (false) { // what to check here?
+			throw new OSCSerializeException("Error adding packet length header");
+		}
 	}
 
 	/**

--- a/modules/core/src/main/java/com/illposed/osc/OSCSerializerAndParserBuilder.java
+++ b/modules/core/src/main/java/com/illposed/osc/OSCSerializerAndParserBuilder.java
@@ -29,6 +29,10 @@ public class OSCSerializerAndParserBuilder {
 		this.usingDefaultHandlers = true;
 	}
 
+	public void setNetworkProtocol(NetworkProtocol networkProtocol) {
+		this.properties.put("networkProtocol", networkProtocol);
+	}
+
 	// Public API
 	@SuppressWarnings("WeakerAccess")
 	public Map<Character, ArgumentHandler> getIdentifierToTypeMapping() {

--- a/modules/core/src/main/java/com/illposed/osc/transport/OSCPortInBuilder.java
+++ b/modules/core/src/main/java/com/illposed/osc/transport/OSCPortInBuilder.java
@@ -48,6 +48,7 @@ public class OSCPortInBuilder {
 
 		if (parserBuilder == null) {
 			parserBuilder = new OSCSerializerAndParserBuilder();
+			parserBuilder.setNetworkProtocol(networkProtocol);
 		}
 
 		if (packetListeners == null) {

--- a/modules/core/src/main/java/com/illposed/osc/transport/OSCPortOutBuilder.java
+++ b/modules/core/src/main/java/com/illposed/osc/transport/OSCPortOutBuilder.java
@@ -30,6 +30,7 @@ public class OSCPortOutBuilder {
 
 		if (serializerBuilder == null) {
 			serializerBuilder = new OSCSerializerAndParserBuilder();
+			serializerBuilder.setNetworkProtocol(networkProtocol);
 		}
 
 		return new OSCPortOut(


### PR DESCRIPTION
When sending through TCP, OSC 1.0 uses a packet length header (PLH) (four bytes at the start of outgoing data) to indicate to the receiver how long the packet will be. The current TCP transport in JavaOSC doesn't add this PLH to outgoing data, so other OSC-compliant apps won't process the data correctly; and it doesn't read this PLH from incoming data, so it won't process the data from other OSC-compliant apps correctly.

This PR correctly adds the PLH to outgoing data. For incoming data, it simply discards the PLH. A more complete solution would use the PLH to correctly process incoming OSC messages that are split across multiple TCP packets.