### PR TITLE
Allow characters *?,[]{} in OSC message

### DIFF
--- a/modules/core/src/main/java/com/illposed/osc/OSCMessage.java
+++ b/modules/core/src/main/java/com/illposed/osc/OSCMessage.java
@@ -23,10 +23,10 @@ public class OSCMessage implements OSCPacket {
 	/**
 	 * Java regular expression pattern matching a single invalid character.
 	 * The invalid characters are:
-	 * ' ', '#', '*', ',', '?', '[', ']', '{', '}'
+	 * ' ', '#'
 	 */
 	private static final Pattern ILLEGAL_ADDRESS_CHAR
-			= Pattern.compile("[ #*,?\\[\\]{}]");
+			= Pattern.compile("[ #]");
 
 	private final String address;
 	private final List<Object> arguments;


### PR DESCRIPTION
PR for [Issue #67](https://github.com/hoijui/JavaOSC/issues/67)